### PR TITLE
Fix repository lookup fields

### DIFF
--- a/sakura-api/src/interfaces/downloaded-track.interface.ts
+++ b/sakura-api/src/interfaces/downloaded-track.interface.ts
@@ -5,5 +5,5 @@ export interface DownloadedTrack {
   file_path: string;
   duration: number;
   createdAt?: Date; // Timestamp for when the record was created
-  updatedAt?: Date; // Timestamp for when the record was last
+  updatedAt?: Date; // Timestamp for when the record was last updated
 }

--- a/sakura-api/src/repositories/downloaded-track.repository.ts
+++ b/sakura-api/src/repositories/downloaded-track.repository.ts
@@ -5,7 +5,9 @@ import { DownloadedTrackModel } from '../models/downloaded-track.model.js';
 export class DownloadedTrackRepository implements IRepository<DownloadedTrack> {
   async get(id: string): Promise<DownloadedTrack> {
     try {
-      const track = await DownloadedTrackModel.findOne({ id }).exec();
+      const track = await DownloadedTrackModel.findOne({
+        sakura_audio_id: id,
+      }).exec();
       if (!track) {
         throw new Error(`DownloadedTrack with id ${id} not found`);
       }
@@ -38,7 +40,7 @@ export class DownloadedTrackRepository implements IRepository<DownloadedTrack> {
   async update(id: string, item: DownloadedTrack): Promise<DownloadedTrack> {
     try {
       const updatedTrack = await DownloadedTrackModel.findOneAndUpdate(
-        { id },
+        { sakura_audio_id: id },
         item,
         { new: true }
       ).exec();
@@ -54,7 +56,9 @@ export class DownloadedTrackRepository implements IRepository<DownloadedTrack> {
 
   async delete(id: string): Promise<void> {
     try {
-      const result = await DownloadedTrackModel.deleteOne({ id }).exec();
+      const result = await DownloadedTrackModel.deleteOne({
+        sakura_audio_id: id,
+      }).exec();
       if (result.deletedCount === 0) {
         throw new Error(`DownloadedTrack with id ${id} not found for deletion`);
       }


### PR DESCRIPTION
## Summary
- fix lookup field names in track repository
- clarify interface comment

## Testing
- `npm test` in `sakura-api`
- `npm test` in `sakura-signal`
- `go test ./...` in `sakura-media-server`


------
https://chatgpt.com/codex/tasks/task_e_685056680bc8832398e9d4bb8473dba4